### PR TITLE
update Dockerfile to support local running

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get update -q && \
     htop \
 	nginx \
 	make \
+	tmux \
 	vim \
 	&& \
 	apt-get -qq purge && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,3 +45,5 @@ RUN pip install --no-cache -r /tmp/requirements.txt
 COPY postBuild /tmp
 COPY jupyter_notebook_config.py /home/${NB_USER}/.jupyter/
 RUN sh /tmp/postBuild
+
+CMD code-server --auth none --bind-addr 0.0.0.0 --port 5000

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update -q && \
 	apt-get install -yqq \
 	curl \
 	git \
+    htop \
 	nginx \
 	make \
 	vim \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update -q && \
 	apt-get install -yqq \
 	curl \
 	git \
-    htop \
+	htop \
 	nginx \
 	make \
 	tmux \


### PR DESCRIPTION
adding `CMD` doesn't change how `binder` will launch the environment but does allow for some inter-operability with local builds.

you can now
`docker build -t demo .`
`docker run --name demo-env -p 5000:5000 demo`

and access the VSCode environment.